### PR TITLE
Remove deprecated crypto npm module

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   "devDependencies": {},
   "dependencies": {
     "bluebird": "^2.10.2",
-    "crypto": "0.0.3",
     "debug": "^2.6.8",
     "fast-csv": "^2.4.0",
     "fs": "0.0.1-security",


### PR DESCRIPTION
`crypto` has been marked as deprecated by npm since [August 26, 2016](https://github.com/npm/deprecate-holder/commit/67a88808389068bb0692a68b2bfa1fe762cb889b). It
was deprecated because it was added to Node itself. Looking back in the
documentation, it looks like Node has had crypto functionality built in
since 0.10.x, so this shouldn't break on any remotely recent version of Node.

I tested this by using `mws.reports.search()` and made sure that there was no signature errors or other crypto errors in `lib/AmazonMwsResource.js`.

This module has made working with Amazon MWS than the other SDKs I've tried out. Thanks for making it!