### PR TITLE
Make a block scoped copy of requestParams before submitting request

### DIFF
--- a/lib/AmazonMwsResource.js
+++ b/lib/AmazonMwsResource.js
@@ -348,15 +348,17 @@ AmazonMwsResource.prototype = {
             headers['Content-MD5'] = self.requestParamsJSON.ContentMD5Value;
         }
 
+        // Make a deep copy of the request params, assign to block scoped variable
+        let requestParamsCopy = JSON.parse(JSON.stringify(self.requestParams))
         // Grab client-user-agent before making the request:
         this._AmazonMws.getClientUserAgent(function () {
             if (options.headers) {
                 objectAssign(headers, options.headers);
             }
-            makeRequest();
+            makeRequest(requestParamsCopy);
         });
 
-        function makeRequest() {
+        function makeRequest(requestParamsCopy) {
             var timeout = self._AmazonMws.getApiField('timeout');
             var isInsecureConnection = self._AmazonMws.getApiField('protocol') === 'http';
 
@@ -368,7 +370,7 @@ AmazonMwsResource.prototype = {
                 method: method,
                 headers: headers
             };
-            params.path = params.path + '?' + self.requestParams;
+            params.path = params.path + '?' + requestParamsCopy;
 
             /*debug('params %o ', params);
              debug('body %o ', self.body);*/


### PR DESCRIPTION
Hi,

First off, thanks for creating this library. It's fantastic and has saved me a lot of time!

While using it recently, I was running into a problem where multiple requests that were submitted simultaneously with different parameters were all using the same parameters when the requests actually ran. The parameters used were the parameters from the last submitted request. After some digging, I found that this problem occurs because the request is using a global variable (self.requestParams), which gets overwritten each time a request is submitted. To fix the problem, I created a block scoped variable and assigned a deep copy of the request parameters to it. It seems to have fixed the problem. Please review and let me know if you have any questions.