### PR TITLE
Update dependecies

### DIFF
--- a/lib/AmazonMwsResource.js
+++ b/lib/AmazonMwsResource.js
@@ -5,7 +5,7 @@ var http = require('http');
 var https = require('https');
 var objectAssign = require('object-assign');
 var path = require('path');
-var xml2json = require('xml2json');
+var xml2js = require('xml2js');
 var crypto = require('crypto');
 var _ = require('lodash');
 var qs = require('qs');
@@ -156,17 +156,23 @@ AmazonMwsResource.prototype = {
             //debug('res.headers %o ', res.headers);
             if (RESPONSE_CONTENT_TYPE.indexOf(res.headers['content-type'].toLowerCase()) > -1) {
                 debug('It is XML Response');
-                response = xml2json.toJson(response);
-                //debug('response after parsing JSON %o ', response);
-                response = JSON.parse(response);
-                response.Headers = {
-                    'x-mws-quota-max': res.headers['x-mws-quota-max'] || 'unknown',
-                    'x-mws-quota-remaining': res.headers['x-mws-quota-remaining'] || 'unknown',
-                    'x-mws-quota-resetson': res.headers['x-mws-quota-resetson'] || 'unknown',
-                    'x-mws-timestamp': res.headers['x-mws-timestamp']
-                };
-                //debug('after adding header response', response);
-                return callback(null, response);
+                var parser = new xml2js.Parser({
+                  explicitArray: false,
+                  ignoreAttrs: true
+                });
+
+                parser.parseString(response, function(err, obj) {
+                  //debug('response after parsing JSON %o ', response);
+                  //response = JSON.parse(response);
+                  obj.Headers = {
+                      'x-mws-quota-max': res.headers['x-mws-quota-max'] || 'unknown',
+                      'x-mws-quota-remaining': res.headers['x-mws-quota-remaining'] || 'unknown',
+                      'x-mws-quota-resetson': res.headers['x-mws-quota-resetson'] || 'unknown',
+                      'x-mws-timestamp': res.headers['x-mws-timestamp']
+                  };
+                  //debug('after adding header response', response);
+                  return callback(null, obj);
+                });
             } else {
                 debug('It is NON-XML Response');
                 var data = [];

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
         "fast-csv": "^2.4.0",
         "fs-extra": "^5.0.0",
         "lodash": "^4.17.4",
-        "node-expat": "2.3.16",
         "object-assign": "^4.1.0",
         "qs": "^6.5.1",
         "xml2json": "^0.11.0"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "lodash": "^4.17.4",
         "object-assign": "^4.1.0",
         "qs": "^6.5.1",
-        "xml2json": "^0.11.0"
+        "xml2js": "^0.4.19"
     },
     "license": "MIT",
     "scripts": {


### PR DESCRIPTION
Using xml2js you can avoid installing python witch is a dependecy of node-expat witch is a dependecy of xml2json