### PR TITLE
New user's options, new example with new options and fixings

### DIFF
--- a/examples/javaScript/feeds/getFeedSubmissionResultRaw.js
+++ b/examples/javaScript/feeds/getFeedSubmissionResultRaw.js
@@ -1,0 +1,29 @@
+'use strict';
+var fs = require("fs");
+
+var accessKey = process.env.AWS_ACCESS_KEY_ID || 'YOUR_KEY';
+var accessSecret = process.env.AWS_SECRET_ACCESS_KEY || 'YOUR_SECRET';
+
+var amazonMws = require('../../../lib/amazon-mws')(accessKey, accessSecret);
+
+/*  use __RAW__ to get the raw response in response->data; this along  with __CHARSET__ do not get written in the request. */
+function GetFeedSubmissionResultRaw(FeedSubmissionId) {
+
+    amazonMws.feeds.search({
+        'Version': '2009-01-01',
+        'Action': 'GetFeedSubmissionResult',
+        'SellerId': 'SELLER_ID',
+        'MWSAuthToken': 'MWS_AUTH_TOKEN',
+        'FeedSubmissionId': FeedSubmissionId,
+        __RAW__ : true 
+    }, (error, response) => { 
+        if (error) {
+            console.log('error ', error);
+            return;
+        }
+        fs.writeFileSync('response.txt',response.data)
+        console.log('Headers', response.Headers);
+    });
+};
+
+GetFeedSubmissionResultRaw('10101010XXX');

--- a/lib/AmazonMwsResource.js
+++ b/lib/AmazonMwsResource.js
@@ -121,7 +121,7 @@ AmazonMwsResource.prototype = {
         };
     },
 
-    _responseHandler: function (requestParamsJSONCopy, req, callback) {
+    _responseHandler: function (requestParamsJSONCopy, req, userOptions, callback) {
         var self = this;
 
         function processXml(o, action) {
@@ -170,6 +170,7 @@ AmazonMwsResource.prototype = {
                         'x-mws-timestamp': res.headers['x-mws-timestamp'],
                         'content-type': res.headers['content-type'] || 'unknown',
                         'content-length': res.headers['content-length'] || 'unknown',
+                        'content-md5': res.headers['content-md5'],
                         'date': res.headers['date'] || 'unknown',
 
                     };
@@ -189,9 +190,9 @@ AmazonMwsResource.prototype = {
                 'x-mws-quota-resetson': res.headers['x-mws-quota-resetson'] || 'unknown',
                 'x-mws-timestamp': res.headers['x-mws-timestamp'],
                 'content-type': content_type || 'unknown',
-                'content-charset' : charset || 'unknown',
+                'content-charset': charset || 'unknown',
                 'content-length': res.headers['content-length'] || 'unknown',
-                'content-md5' : res.headers['content-md5'],
+                'content-md5': res.headers['content-md5'],
                 'date': res.headers['date'] || 'unknown',
             }
             response.data = data;
@@ -213,6 +214,8 @@ AmazonMwsResource.prototype = {
                     'x-mws-timestamp': res.headers['x-mws-timestamp'],
                     'content-type': res.headers['content-type'] || 'unknown',
                     'content-length': res.headers['content-length'] || 'unknown',
+                    'content-md5': res.headers['content-md5'],
+
                     'date': res.headers['date'] || 'unknown',
                 };
                 //debug('after adding header res', res);
@@ -237,9 +240,15 @@ AmazonMwsResource.prototype = {
             var dbgResponseBuffer = [];
             var headers = req.res.headers;
             /*  new stuff */
-            var content_type = headers['content-type'].split(';')[0];
-            var charset = headers['content-type'].split(';')[1].match(/^((\b[^\s=]+)=(([^=]|\\=)+))*$/)[3];
-            debug({response:{content_type:content_type, charset:charset}});
+            var charset;
+            var content_type;
+            debug({ headers: req.res.headers })
+            if(headers['content-type'].indexOf('charset')>-1){
+                content_type = headers['content-type'].split(';')[0];
+                charset = headers['content-type'].split(';')[1].match(/^((\b[^\s=]+)=(([^=]|\\=)+))*$/)[3];
+            }
+            else
+                content_type = headers['content-type'];
 
             res.on('data', function (chunk) {
                 dbgResponseBuffer.push(chunk);
@@ -249,14 +258,21 @@ AmazonMwsResource.prototype = {
                 //const writeFileSync = require('fs').writeFileSync;
 
                 // let the user do whathever he wants with this type of data, like xlsx spreadsheets
-                if (content_type.indexOf('application') > -1) {
-                    processBinaryFile(res,content_type,charset,buf,(data)=>{
+                if (userOptions.userRaw == true || content_type.indexOf('application') > -1 && content_type.indexOf('application/xml') > -1) {
+                    processBinaryFile(res, content_type, charset, buf, (data) => {
                         callback.call(self, null, data);
                     })
                 }
                 else {
-                    var iconv = new Iconv(charset, 'UTF-8');
-                    var responseString = iconv.convert(buf).toString();
+                    if(userOptions.userCharset)
+                        charset = userOptions.userCharset;
+                    var responseString;
+                    if (charset) {
+                        var iconv = new Iconv(charset, 'UTF-8');
+                        responseString = iconv.convert(buf).toString();
+                    }
+                    else
+                        responseString = buf.toString();
                     try {
 
                         processResponseType(res, responseString, function (error, response) {
@@ -366,8 +382,23 @@ AmazonMwsResource.prototype = {
     _request: function (method, path, data, auth, options, callback) {
         var self = this;
         //debug('path ', path);
+        debug('data', data);
         self.requestParams = data;
         self.body = '';
+
+        var userRaw;
+        var userCharset;
+        /**custom option passed by user, a better way to do this would be nice */
+        {
+            if (data.__RAW__) {
+                userRaw = data.__RAW__;
+                delete data.__RAW__
+            }
+            if (data.__CHARSET__) {
+                userCharset = data.__CHARSET__;
+                delete data.__CHARSET__;
+            }
+        }
         if (!self.requestParams.Version) {
             return callback.call(
                 self,
@@ -484,7 +515,7 @@ AmazonMwsResource.prototype = {
             var req = (isInsecureConnection ? http : https).request(params);
 
             req.setTimeout(timeout, self._timeoutHandler(timeout, req, callback));
-            req.on('response', self._responseHandler(requestParamsJSONCopy, req, callback));
+            req.on('response', self._responseHandler(requestParamsJSONCopy, req, { userCharset, userRaw }, callback));
             req.on('error', self._errorHandler(req, callback));
 
             req.on('socket', function (socket) {


### PR DESCRIPTION
--Added __RAW__ and __CHARSET__ to api's request methods:
	`__RAW__ : boolean` > the response contains the raw data
	`__CHARSET__: string` > set the wanted response charset
These request parameters aren't sent to amazon, but used by the _request function to handle specific user options, `__RAW__` indeed is useful as hell, since amazon's responses, feeds ahead, are nasty.

--Fixed issues pointed by Bhushankumar

--New example with `__RAW__` option for GetFeedSubmissionResult
guess what I got from amazon:
```
Feed Processing Summary:
	Number of records processed		1
	Number of records successful		1

```
not regular tabulated file indeed, I'd get undefined responseError without `__RAW__`, because the lib is trying to parse it and fails, maybe we should throw all the nasty stuff to processBinaryFile