### PR TITLE
Added small check to fix csv when response from amazon does not start with headers

### DIFF
--- a/lib/AmazonMwsResource.js
+++ b/lib/AmazonMwsResource.js
@@ -66,10 +66,10 @@ AmazonMwsResource.prototype = {
 
     createFullPath: function (commandPath, urlData) {
         return path.join(
-          this.basePath(urlData),
-          this.path(urlData),
-          typeof commandPath === 'function' ?
-            commandPath(urlData) : commandPath
+            this.basePath(urlData),
+            this.path(urlData),
+            typeof commandPath === 'function' ?
+                commandPath(urlData) : commandPath
         ).replace(/\\/g, '/'); // ugly workaround for Windows
     },
 
@@ -159,19 +159,24 @@ AmazonMwsResource.prototype = {
                 ignoreEmpty: true,
                 trim: true
             };
+
+            if (responseString.includes('\n\n')) {
+                responseString = responseString.split('\n\n')[1];
+            }
+
             csv.fromString(responseString, options)
-              .on('data', function (value) {
-                  data.push(value);
-              })
-              .on('end', function () {
-                  var items = {};
-                  items.data = data;
-                  return callback(null, items);
-              })
-              .on('error', function (error) {
-                  debug('error ', error);
-                  return callback(error);
-              });
+                .on('data', function (value) {
+                    data.push(value);
+                })
+                .on('end', function () {
+                    var items = {};
+                    items.data = data;
+                    return callback(null, items);
+                })
+                .on('error', function (error) {
+                    debug('error ', error);
+                    return callback(error);
+                });
         }
 
         function processResponseType(res, responseString, callback) {


### PR DESCRIPTION
I have elaborated on this issue in #113 but essentially when there are not headers at the top of the text in the text/plain csv response from Amazon the fast-csv library is not able to handle it (rightfully). I added a simple check because I did not want to break any other csv responses I did not currently know about and I am seeing this same pattern for text/plain responses that do not start with headers. 

Also, ran your linter and it made some formatting changes if you are wondering why those are in the PR. 

I looked through your README and did not see a specific expectation when it comes to PRs so let me know if you would prefer this done any other way.