### PR TITLE
Docs: Correct TypeScript imports statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ var amazonMws = require('amazon-mws')('AWS_ACCESS_KEY_ID','AWS_SECRET_ACCESS_KEY
 
 ## Configuration Using TypeScript
 ```typescript
-import * as MwsApi from 'amazon-mws';
+import MwsApi from 'amazon-mws';
 
 const amazonMws = new MwsApi();
 amazonMws.setApiKey(accessKey, accessSecret);

--- a/examples/typeScript/reports/getReport.ts
+++ b/examples/typeScript/reports/getReport.ts
@@ -1,7 +1,7 @@
 const accessKey = process.env.AWS_ACCESS_KEY_ID || 'YOUR_KEY';
 const accessSecret = process.env.AWS_SECRET_ACCESS_KEY || 'YOUR_SECRET';
 
-import * as MwsApi from 'amazon-mws';
+import MwsApi from 'amazon-mws';
 
 const amazonMws = new MwsApi();
 amazonMws.setApiKey(accessKey, accessSecret);

--- a/examples/typeScript/reports/getReportList.ts
+++ b/examples/typeScript/reports/getReportList.ts
@@ -1,7 +1,7 @@
 const accessKey = process.env.AWS_ACCESS_KEY_ID || 'YOUR_KEY';
 const accessSecret = process.env.AWS_SECRET_ACCESS_KEY || 'YOUR_SECRET';
 
-import * as MwsApi from 'amazon-mws';
+import MwsApi from 'amazon-mws';
 
 const amazonMws = new MwsApi();
 amazonMws.setApiKey(accessKey, accessSecret);


### PR DESCRIPTION
Using amazon-mws in TypeScript, I used the reference docs and got an error (`TypeError: AmazonMWS is not a constructor`).

The TypeScript compiler also complained.

Changing to the updated below works in TypeScript.