### PR TITLE
Trim contentType split 

### DIFF
--- a/lib/AmazonMwsResource.js
+++ b/lib/AmazonMwsResource.js
@@ -244,11 +244,12 @@ AmazonMwsResource.prototype = {
             /**
              * Separate the charset & content type
              */
-            if (contentType.indexOf('charset') > -1 && contentType.split(';')[ 0 ] && contentType.split(';')[ 1 ]) {
-                if (contentType.split(';')[ 1 ] && contentType.split(';')[ 1 ].match(/^((\b[^\s=]+)=(([^=]|\\=)+))*$/)[ 3 ]) {
-                    charset = contentType.split(';')[ 1 ].match(/^((\b[^\s=]+)=(([^=]|\\=)+))*$/)[ 3 ];
+            var contentTypeArray = contentType.split(';').map(function (value) { return value.trim(); });
+            if (contentType.indexOf('charset') > -1 && contentTypeArray[0] && contentTypeArray[1]) {
+                if (contentTypeArray[1] && contentTypeArray[1].match(/^((\b[^\s=]+)=(([^=]|\\=)+))*$/)[3]) {
+                    charset = contentTypeArray[1].match(/^((\b[^\s=]+)=(([^=]|\\=)+))*$/)[3];
                 }
-                contentType = contentType.split(';')[ 0 ].toLowerCase();
+                contentType = contentTypeArray[0].toLowerCase();
             }
 
             var ResponseHeaders = {


### PR DESCRIPTION
Trim contentType split  since it can contains whitespace between type and charset. i.e.: `text/xml; charset=utf-8`
When that occurs, match regext return null instead of array.